### PR TITLE
Add Docker files for deployment and development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.4
+FROM python:3.8-slim-buster
+LABEL com.alces-flight.concertim.role=cluster_builder com.alces-flight.concertim.version=0.0.1
+
+WORKDIR /app
+
+COPY requirements.txt /app
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install -r requirements.txt
+
+COPY . /app
+
+EXPOSE 42378
+
+CMD ["flask", "--app", "cluster_builder", "run", "-h", "0.0.0.0", "-p", "42378"]

--- a/README.md
+++ b/README.md
@@ -16,14 +16,68 @@ All required configuration to access the cloud environment is sent in the
 request to build a cluster.  More details can be found in the [API
 documentation](/docs/api.md).
 
+### Cluster type definitions
+
+Concertim cluster builder needs to be configured with the available cluster
+type definitions.  This is done by copying (or symlinking) files into
+[instance/cluster-types-enabled/](instance/cluster-types-enabled/).
+
+Currently, there is no documentation on the format for the cluster type
+definition files beyond the [well-documented
+examples](cluster-types-examples/).  They should prove sufficient.
+
+In production, you may wish to use a docker volume to contain the cluster type
+definitions.  If so, the volume should be mounted on the container at
+`/app/instance/cluster-types-enabled/`.
 
 ## Installation
 
-XXX TBC
+Concertim Cluster Builder is intended to be deployed as a Docker container.
+There is a Dockerfile in this repo that the image can be built from.  The
+cluster builder service is configured to run on port `42378` of the container.
 
+An image can be built with the following command:
+
+```
+docker build --tag concertim-cluster-builder:latest .
+```
 
 ## Usage
 
-XXX TBC: How to start the service.
+Once the docker image is built (see [Installation](#installation) above) a
+container can be started from that image with the following command.  You may
+wish to change the port and interface that the service is published on.
 
-[API documentation](/docs/api.md) is available.
+```
+docker run --rm --name concertim-cluster-builder --publish 127.0.0.1:42378:42378 concertim-cluster-builder
+```
+
+The container will need to be able to receive HTTP requests from the
+concertim-visualisation-app container and be able to make HTTP requests to the
+openstack containers, specifically keystone and heat.  Configuring the
+container networks to support that is left as an exercise for the reader.
+
+## HTTP API
+
+The HTTP API is documented in the [API documentation](/docs/api.md).
+
+
+## Development
+
+There is a [docker-compose](docker-compose.yml) file that creates a docker
+container suitable for development. Note this docker-compose.yml file is not
+intended for a production deployment.
+
+The development docker container can be started with:
+
+```
+docker compose up
+```
+
+Any changes made to the local source code will be automatically picked up by
+the service running inside the container.
+
+[Example cluster type definitions](cluster-types-examples/) are available.
+These can be installed by symlinking them into
+`instance/cluster-types-enabled/`.  See [configuration](#configuration) above
+for more details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+# This docker compose file is intended for developing
+# concertim-cluster-builder.  It is *NOT* suitable for production usage.  See
+# the README.md for production installation instructions.
+services:
+  cluster_builder: 
+    build:
+      context: .
+
+    # flask requires SIGINT to stop gracefully
+    # (default stop signal from Compose is SIGTERM)
+    stop_signal: SIGINT
+
+    ports:
+      - '127.0.0.1:42378:42378'
+
+    # Override the command in the Dockerfile to start add in the `--debug`
+    # flag.  Is there a better way of appending a single argument?
+    command: ["flask", "--app", "cluster_builder", "run", "-h", "0.0.0.0", "-p", "42378", "--debug"]
+
+    # Mount `.` to `/app` to allow editing on the local and having flask automatically reload.
+    volumes:
+      - ./:/app


### PR DESCRIPTION
* Added a Dockerfile.
* Added a docker-compose.yml file suitable for building a development container from the Dockerfile.
* Added instructions to the README on how to use the Dockerfile to install a container suitable for production usage.