### PR TITLE
Update required pattern for example cluster type cluster name parameter

### DIFF
--- a/examples/cluster-types/hpc-cluster-building-blocks.yaml
+++ b/examples/cluster-types/hpc-cluster-building-blocks.yaml
@@ -26,7 +26,7 @@ parameters:
     constraints:
       - length: { min: 6, max: 255 }
         description: Cluster name must be between 6 and 255 characters
-      - allowed_pattern: "[a-zA-Z]+[a-zA-Z0-9\\-\\_]*"
+      - allowed_pattern: "^[a-zA-Z][a-zA-Z0-9\\-_]*$"
         description: Cluster name can contain only alphanumeric characters, hyphens and underscores
 
   external-network:


### PR DESCRIPTION
Updates the regex for the `clustername` parameter for the example cluster type, to ensure it allows and only contains alphanumeric characters, hyphens and underscores when applied in an html form input.

There is some tricky behaviour here as cluster builder requires each `\` in the regex to be escaped - care must be made to ensure these extra `\` are not carried over (or escaped again) when this pattern is used by the concertim visualiser app.

I expect we will find other quirks for handling regex passed from one application to another during development.