### PR TITLE
Support for adding build labels to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 # syntax=docker/dockerfile:1.4
 FROM python:3.8-slim-buster
-LABEL com.alces-flight.concertim.role=cluster_builder com.alces-flight.concertim.version=0.0.1
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REVISION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.revision=$BUILD_REVISION
+LABEL org.opencontainers.image.title="Alces Concertim Cluster Builder"
 
 WORKDIR /app
 


### PR DESCRIPTION
The labels use the format specified in https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1.  The values for the labels are calculated and injected as part of https://github.com/alces-flight/concertim-ansible-playbook/pull/69.