### PR TITLE
Fix tests on CI

### DIFF
--- a/cluster_builder/__init__.py
+++ b/cluster_builder/__init__.py
@@ -45,21 +45,22 @@ def configure_logging(app):
                 'stream': 'ext://flask.logging.wsgi_errors_stream',
                 'formatter': 'default'
             },
-            'file': {
-                'class': 'logging.FileHandler',
-                'filename': app.config['LOG_FILE'],
-                'formatter': 'default'
-            }
         },
         'root': {
             'level': app.config['LOG_LEVEL'].upper(),
-            'handlers': ['wsgi', 'file']
+            'handlers': []
         }
     }
-    if sys.stdout.isatty():
-        config['root']['handlers'] = ['wsgi', 'file']
-    else:
-        config['root']['handlers'] = ['file']
+    log_file = app.config['LOG_FILE']
+    if log_file is not None:
+        config['handlers']['file'] = {
+            'class': 'logging.FileHandler',
+            'filename': log_file,
+            'formatter': 'default'
+        }
+        config['root']['handlers'].append('file')
+    if log_file is None or sys.stdout.isatty():
+        config['root']['handlers'].append('wsgi')
     dictConfig(config)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,14 @@ from cluster_builder import create_app
 def app():
     instance_path = tempfile.mkdtemp()
     print(f"instance_path set to {instance_path}", file=sys.stderr)
-    app = create_app(instance_path=instance_path)
-    app.config.update({
+    test_config = {
         "TESTING": True,
         "DEBUG" : True,
-        "JWT_SECRET": "TEST_SECRET"
-        })
+        "JWT_SECRET": "TEST_SECRET",
+        "LOG_LEVEL": "DEBUG",
+        "LOG_FILE": None,
+    }
+    app = create_app(instance_path=instance_path, test_config=test_config)
 
     yield app
 


### PR DESCRIPTION
Previously starting the app failed if `LOG_FILE` was not specified.  Now, if `LOG_FILE` is `None`, we don't create the log file handler and force logging to stdout.