### PR TITLE
Specify volume names

### DIFF
--- a/examples/cluster-types/cfd-jumpstart/components/gateway.yaml
+++ b/examples/cluster-types/cfd-jumpstart/components/gateway.yaml
@@ -94,11 +94,13 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: {get_param: solo-image}
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       size: 16
 
   gateway-vol-shared-storage:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol-shared-storage, get_param: clustername]]}
       size: {get_param: storage-size}
 
   gateway-vol-shared-storage-attach:

--- a/examples/cluster-types/cfd-jumpstart/components/node.yaml
+++ b/examples/cluster-types/cfd-jumpstart/components/node.yaml
@@ -113,5 +113,6 @@ resources:
   node-vol:
     type: OS::Cinder::Volume
     properties:
+      name: { list_join: ['-', [{ list_join: [ '', ['node', {get_attr: [node-pad, value]} ]]}, 'vol', { get_param: clustername }]] }
       image: { get_param: solo-image }
       size: 16

--- a/examples/cluster-types/container-cruncher-large/components/gateway.yaml
+++ b/examples/cluster-types/container-cruncher-large/components/gateway.yaml
@@ -94,11 +94,13 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: {get_param: solo-image}
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       size: 16
 
   gateway-vol-shared-storage:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol-shared-storage, get_param: clustername]]}
       size: {get_param: storage-size}
 
   gateway-vol-shared-storage-attach:

--- a/examples/cluster-types/container-cruncher-large/components/node.yaml
+++ b/examples/cluster-types/container-cruncher-large/components/node.yaml
@@ -113,5 +113,6 @@ resources:
   node-vol:
     type: OS::Cinder::Volume
     properties:
+      name: { list_join: ['-', [{ list_join: [ '', ['node', {get_attr: [node-pad, value]} ]]}, 'vol', { get_param: clustername }]] }
       image: { get_param: solo-image }
       size: 16

--- a/examples/cluster-types/container-cruncher-medium/components/gateway.yaml
+++ b/examples/cluster-types/container-cruncher-medium/components/gateway.yaml
@@ -94,11 +94,13 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: {get_param: solo-image}
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       size: 16
 
   gateway-vol-shared-storage:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol-shared-storage, get_param: clustername]]}
       size: {get_param: storage-size}
 
   gateway-vol-shared-storage-attach:

--- a/examples/cluster-types/container-cruncher-medium/components/node.yaml
+++ b/examples/cluster-types/container-cruncher-medium/components/node.yaml
@@ -113,5 +113,6 @@ resources:
   node-vol:
     type: OS::Cinder::Volume
     properties:
+      name: { list_join: ['-', [{ list_join: [ '', ['node', {get_attr: [node-pad, value]} ]]}, 'vol', { get_param: clustername }]] }
       image: { get_param: solo-image }
       size: 16

--- a/examples/cluster-types/container-cruncher-small/components/gateway.yaml
+++ b/examples/cluster-types/container-cruncher-small/components/gateway.yaml
@@ -93,12 +93,14 @@ resources:
   gateway-vol:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       image: {get_param: solo-image}
       size: 16
 
   gateway-vol-shared-storage:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol-shared-storage, get_param: clustername]]}
       size: {get_param: storage-size}
 
   gateway-vol-shared-storage-attach:

--- a/examples/cluster-types/container-cruncher-small/components/node.yaml
+++ b/examples/cluster-types/container-cruncher-small/components/node.yaml
@@ -113,5 +113,6 @@ resources:
   node-vol:
     type: OS::Cinder::Volume
     properties:
+      name: { list_join: ['-', [{ list_join: [ '', ['node', {get_attr: [node-pad, value]} ]]}, 'vol', { get_param: clustername }]] }
       image: { get_param: solo-image }
       size: 16

--- a/examples/cluster-types/jupyterlab-jumpstart/components/gateway-standalone.yaml
+++ b/examples/cluster-types/jupyterlab-jumpstart/components/gateway-standalone.yaml
@@ -104,6 +104,7 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: {get_param: solo-image}
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       size: {get_param: gateway-vol-size}
 
   gateway-ip:

--- a/examples/cluster-types/slurm-standalone/components/gateway-standalone.yaml
+++ b/examples/cluster-types/slurm-standalone/components/gateway-standalone.yaml
@@ -104,6 +104,7 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: {get_param: solo-image}
+      name: {list_join: ['-', [gateway-vol-shared-storage, get_param: clustername]]}
       size: {get_param: gateway-vol-size}
 
   gateway-ip:

--- a/examples/cluster-types/slurm-team-edition/components/gateway.yaml
+++ b/examples/cluster-types/slurm-team-edition/components/gateway.yaml
@@ -94,11 +94,13 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: {get_param: solo-image}
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       size: 16
 
   gateway-vol-shared-storage:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol-shared-storage, get_param: clustername]]}
       size: {get_param: storage-size}
 
   gateway-vol-shared-storage-attach:

--- a/examples/cluster-types/slurm-team-edition/components/infra.yaml
+++ b/examples/cluster-types/slurm-team-edition/components/infra.yaml
@@ -76,4 +76,5 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: {get_param: solo-image}
+      name: {list_join: ['-', [infra01-vol, get_param: clustername]]}
       size: 16

--- a/examples/cluster-types/slurm-team-edition/components/node.yaml
+++ b/examples/cluster-types/slurm-team-edition/components/node.yaml
@@ -113,5 +113,6 @@ resources:
   node-vol:
     type: OS::Cinder::Volume
     properties:
+      name: { list_join: ['-', [{ list_join: [ '', ['node', {get_attr: [node-pad, value]} ]]}, 'vol', { get_param: clustername }]] }
       image: { get_param: solo-image }
       size: 16

--- a/examples/templates/components/gateway-standalone.yaml
+++ b/examples/templates/components/gateway-standalone.yaml
@@ -103,6 +103,7 @@ resources:
     type: OS::Cinder::Volume
     properties:
       image: { get_param: solo-image }
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       size: { get_param: gateway-vol-size }
 
   gateway-ip:

--- a/examples/templates/components/gateway.yaml
+++ b/examples/templates/components/gateway.yaml
@@ -93,12 +93,14 @@ resources:
   gateway-vol:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol, get_param: clustername]]}
       image: { get_param: solo-image }
       size: 16
 
   gateway-vol-shared-storage:
     type: OS::Cinder::Volume
     properties:
+      name: {list_join: ['-', [gateway-vol-shared-storage, get_param: clustername]]}
       size: { get_param: storage-size }
 
   gateway-vol-shared-storage-attach:

--- a/examples/templates/components/node.yaml
+++ b/examples/templates/components/node.yaml
@@ -113,5 +113,6 @@ resources:
   node-vol:
     type: OS::Cinder::Volume
     properties:
+      name: { list_join: ['-', [{ list_join: [ '', ['node', {get_attr: [node-pad, value]} ]]}, 'vol', { get_param: clustername }]] }
       image: { get_param: solo-image }
       size: 16


### PR DESCRIPTION
Aims to resolve #48

Currently volumes are created with extremely long names (e.g. `mycluster--d1alJX-75MTmTjuhUP3unQ-node-group-657avpg5v4bq-4-bm4pskmdxwle-node-vol-elo4pfccgavf`). These are difficult to read and lead to large hover text boxes in visualiser.

This PR therefore updates template logic to specify shorter names for volumes, e.g. `node02-vol-mycluster`